### PR TITLE
Use string based URI for sound name

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -270,13 +270,13 @@ public class RNPushNotificationHelper {
                         visibility = NotificationCompat.VISIBILITY_PRIVATE;
                 }
             }
-            
+
             String channel_id = bundle.getString("channelId");
 
             if(channel_id == null) {
                 channel_id = this.config.getNotificationDefaultChannelId();
             }
-            
+
             NotificationCompat.Builder notification = new NotificationCompat.Builder(context, channel_id)
                     .setContentTitle(title)
                     .setTicker(bundle.getString("ticker"))
@@ -284,7 +284,7 @@ public class RNPushNotificationHelper {
                     .setPriority(priority)
                     .setAutoCancel(bundle.getBoolean("autoCancel", true))
                     .setOnlyAlertOnce(bundle.getBoolean("onlyAlertOnce", false));
-            
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) { // API 24 and higher
                 // Restore showing timestamp on Android 7+
                 // Source: https://developer.android.com/reference/android/app/Notification.Builder.html#setShowWhen(boolean)
@@ -297,7 +297,7 @@ public class RNPushNotificationHelper {
                 // Changing Default mode of notification
                 notification.setDefaults(Notification.DEFAULT_LIGHTS);
             }
-      
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) { // API 20 and higher
               String group = bundle.getString("group");
 
@@ -360,7 +360,7 @@ public class RNPushNotificationHelper {
                     largeIconBitmap = BitmapFactory.decodeResource(res, largeIconResId);
                 }
             }
-            
+
             if (largeIconBitmap != null){
               notification.setLargeIcon(largeIconBitmap);
             }
@@ -374,7 +374,7 @@ public class RNPushNotificationHelper {
             if (subText != null) {
                 notification.setSubText(subText);
             }
- 
+
             String bigText = bundle.getString("bigText");
 
             if (bigText == null) {
@@ -469,32 +469,32 @@ public class RNPushNotificationHelper {
 
                 vibratePattern = new long[]{0, vibration};
 
-                notification.setVibrate(vibratePattern); 
+                notification.setVibrate(vibratePattern);
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) { 
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
               // Define the shortcutId
               String shortcutId = bundle.getString("shortcutId");
-              
+
               if (shortcutId != null) {
                 notification.setShortcutId(shortcutId);
               }
- 
+
               Long timeoutAfter = (long) bundle.getDouble("timeoutAfter");
-  
+
               if (timeoutAfter != null && timeoutAfter >= 0) {
                 notification.setTimeoutAfter(timeoutAfter);
               }
             }
 
             Long when = (long) bundle.getDouble("when");
-  
+
             if (when != null && when >= 0) {
               notification.setWhen(when);
             }
 
             notification.setUsesChronometer(bundle.getBoolean("usesChronometer", false));
-                
+
             notification.setChannelId(channel_id);
             notification.setContentIntent(pendingIntent);
 
@@ -677,20 +677,14 @@ public class RNPushNotificationHelper {
         if (soundName == null || "default".equalsIgnoreCase(soundName)) {
             return RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
         } else {
-
             // sound name can be full filename, or just the resource name.
             // So the strings 'my_sound.mp3' AND 'my_sound' are accepted
             // The reason is to make the iOS and android javascript interfaces compatible
-
-            int resId;
-            if (context.getResources().getIdentifier(soundName, "raw", context.getPackageName()) != 0) {
-                resId = context.getResources().getIdentifier(soundName, "raw", context.getPackageName());
-            } else {
+            if (context.getResources().getIdentifier(soundName, "raw", context.getPackageName()) == 0) {
                 soundName = soundName.substring(0, soundName.lastIndexOf('.'));
-                resId = context.getResources().getIdentifier(soundName, "raw", context.getPackageName());
             }
 
-            return Uri.parse("android.resource://" + context.getPackageName() + "/" + resId);
+            return Uri.parse("android.resource://" + context.getPackageName() + "/raw/" + soundName);
         }
     }
 
@@ -724,7 +718,7 @@ public class RNPushNotificationHelper {
     @RequiresApi(api = Build.VERSION_CODES.M)
     public WritableArray getDeliveredNotifications() {
       WritableArray result = Arguments.createArray();
-  
+
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
         return result;
       }
@@ -842,10 +836,10 @@ public class RNPushNotificationHelper {
 
     public List<String> listChannels() {
       List<String> channels = new ArrayList<>();
-      
+
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
           return channels;
-      
+
       NotificationManager manager = notificationManager();
 
       if (manager == null)
@@ -863,7 +857,7 @@ public class RNPushNotificationHelper {
     public boolean channelBlocked(String channel_id) {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
           return false;
-      
+
       NotificationManager manager = notificationManager();
 
       if (manager == null)
@@ -880,7 +874,7 @@ public class RNPushNotificationHelper {
     public boolean channelExists(String channel_id) {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
           return false;
-      
+
       NotificationManager manager = notificationManager();
 
       if (manager == null)
@@ -894,7 +888,7 @@ public class RNPushNotificationHelper {
     public void deleteChannel(String channel_id) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
             return;
-        
+
         NotificationManager manager = notificationManager();
 
         if (manager == null)
@@ -966,7 +960,7 @@ public class RNPushNotificationHelper {
 
         return checkOrCreateChannel(manager, channelId, channelName, channelDescription, soundUri, importance, vibratePattern);
     }
-    
+
     public boolean isApplicationInForeground() {
         ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
         List<RunningAppProcessInfo> processInfos = activityManager.getRunningAppProcesses();

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -270,13 +270,13 @@ public class RNPushNotificationHelper {
                         visibility = NotificationCompat.VISIBILITY_PRIVATE;
                 }
             }
-
+            
             String channel_id = bundle.getString("channelId");
 
             if(channel_id == null) {
                 channel_id = this.config.getNotificationDefaultChannelId();
             }
-
+            
             NotificationCompat.Builder notification = new NotificationCompat.Builder(context, channel_id)
                     .setContentTitle(title)
                     .setTicker(bundle.getString("ticker"))
@@ -284,7 +284,7 @@ public class RNPushNotificationHelper {
                     .setPriority(priority)
                     .setAutoCancel(bundle.getBoolean("autoCancel", true))
                     .setOnlyAlertOnce(bundle.getBoolean("onlyAlertOnce", false));
-
+            
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) { // API 24 and higher
                 // Restore showing timestamp on Android 7+
                 // Source: https://developer.android.com/reference/android/app/Notification.Builder.html#setShowWhen(boolean)
@@ -297,7 +297,7 @@ public class RNPushNotificationHelper {
                 // Changing Default mode of notification
                 notification.setDefaults(Notification.DEFAULT_LIGHTS);
             }
-
+      
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) { // API 20 and higher
               String group = bundle.getString("group");
 
@@ -360,7 +360,7 @@ public class RNPushNotificationHelper {
                     largeIconBitmap = BitmapFactory.decodeResource(res, largeIconResId);
                 }
             }
-
+            
             if (largeIconBitmap != null){
               notification.setLargeIcon(largeIconBitmap);
             }
@@ -374,7 +374,7 @@ public class RNPushNotificationHelper {
             if (subText != null) {
                 notification.setSubText(subText);
             }
-
+ 
             String bigText = bundle.getString("bigText");
 
             if (bigText == null) {
@@ -469,32 +469,32 @@ public class RNPushNotificationHelper {
 
                 vibratePattern = new long[]{0, vibration};
 
-                notification.setVibrate(vibratePattern);
+                notification.setVibrate(vibratePattern); 
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) { 
               // Define the shortcutId
               String shortcutId = bundle.getString("shortcutId");
-
+              
               if (shortcutId != null) {
                 notification.setShortcutId(shortcutId);
               }
-
+ 
               Long timeoutAfter = (long) bundle.getDouble("timeoutAfter");
-
+  
               if (timeoutAfter != null && timeoutAfter >= 0) {
                 notification.setTimeoutAfter(timeoutAfter);
               }
             }
 
             Long when = (long) bundle.getDouble("when");
-
+  
             if (when != null && when >= 0) {
               notification.setWhen(when);
             }
 
             notification.setUsesChronometer(bundle.getBoolean("usesChronometer", false));
-
+                
             notification.setChannelId(channel_id);
             notification.setContentIntent(pendingIntent);
 
@@ -718,7 +718,7 @@ public class RNPushNotificationHelper {
     @RequiresApi(api = Build.VERSION_CODES.M)
     public WritableArray getDeliveredNotifications() {
       WritableArray result = Arguments.createArray();
-
+  
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
         return result;
       }
@@ -836,10 +836,10 @@ public class RNPushNotificationHelper {
 
     public List<String> listChannels() {
       List<String> channels = new ArrayList<>();
-
+      
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
           return channels;
-
+      
       NotificationManager manager = notificationManager();
 
       if (manager == null)
@@ -857,7 +857,7 @@ public class RNPushNotificationHelper {
     public boolean channelBlocked(String channel_id) {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
           return false;
-
+      
       NotificationManager manager = notificationManager();
 
       if (manager == null)
@@ -874,7 +874,7 @@ public class RNPushNotificationHelper {
     public boolean channelExists(String channel_id) {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
           return false;
-
+      
       NotificationManager manager = notificationManager();
 
       if (manager == null)
@@ -888,7 +888,7 @@ public class RNPushNotificationHelper {
     public void deleteChannel(String channel_id) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
             return;
-
+        
         NotificationManager manager = notificationManager();
 
         if (manager == null)
@@ -960,7 +960,7 @@ public class RNPushNotificationHelper {
 
         return checkOrCreateChannel(manager, channelId, channelName, channelDescription, soundUri, importance, vibratePattern);
     }
-
+    
     public boolean isApplicationInForeground() {
         ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
         List<RunningAppProcessInfo> processInfos = activityManager.getRunningAppProcesses();


### PR DESCRIPTION
The id of a resource can change between builds whereas the notification channel remains. This means that the channel may point to an invalid resource after a rebuild.